### PR TITLE
Update Chapter 12 - trl需要版本0.12.0

### DIFF
--- a/chapter12/Chapter 12 - Fine-tuning Generation Models.ipynb
+++ b/chapter12/Chapter 12 - Fine-tuning Generation Models.ipynb
@@ -17,7 +17,8 @@
    "outputs": [],
    "source": [
     "# %%capture\n",
-    "# !pip install -q accelerate peft bitsandbytes transformers trl sentencepiece"
+    "# !pip install -q accelerate peft bitsandbytes transformers sentencepiece\n",
+    "# !pip install trl==0.12.0"
    ]
   },
   {


### PR DESCRIPTION
若trl版本过高时，SFTTrainer中的dataset_text_field = 'text'参数已经被移除，具体可见：https://github.com/unslothai/unsloth/issues/1264
<img width="1014" alt="daf3954f4321990fe75c76cef119ce0" src="https://github.com/user-attachments/assets/54de8e5c-e323-4d10-a125-aab8dd8bba12" />
