### PR TITLE
Update Chapter 12 - Fine-tuning Generation Models.ipynb

### DIFF
--- a/chapter12/Chapter 12 - Fine-tuning Generation Models.ipynb
+++ b/chapter12/Chapter 12 - Fine-tuning Generation Models.ipynb
@@ -580,7 +580,7 @@
     "\n",
     "output_dir = \"./results\"\n",
     "\n",
-    "# Training arguments\n",
+    "# \n",
     "training_arguments = TrainingArguments(\n",
     "    output_dir=output_dir,\n",
     "    per_device_train_batch_size=2,\n",
@@ -592,6 +592,7 @@
     "    logging_steps=10,\n",
     "    fp16=True,\n",
     "    gradient_checkpointing=True\n",
+    "    report_to="none"\n",
     ")"
    ]
   },


### PR DESCRIPTION
在没有安装 wandb 的环境下运行代码不会上报实验数据。直接运行在 Colab或者装了wandb的计算机会出现这个输出，因为 它们 预装了 wandb。

建议设置 report_to="none" 来修改默认行为

<img width="1160" alt="534bd5f06222c0514c2acee25064e1b" src="https://github.com/user-attachments/assets/a7536ce5-7f55-4fb1-81a5-2848f9e91aee" />
